### PR TITLE
Downgraded error level for failed bibcode search

### DIFF
--- a/ADSOrcid/app.py
+++ b/ADSOrcid/app.py
@@ -325,7 +325,7 @@ class ADSOrcidCelery(ADSCelery):
                                 self.logger.info('Match found {0} -> {1}'.format(fvalue, bibc))
                                 break
                         except Exception, e:
-                            self.logger.error('Exception while searching for matching bibcode for: {}'.format(fvalue))
+                            self.logger.warning('Exception while searching for matching bibcode for: {}'.format(fvalue))
                             self.logger.warning(e.message)
                             
                     


### PR DESCRIPTION
Issue #59 
Not implementing bibcode length check, etc., because DOIs, etc., are also being searched for. Downgraded message from error to warning.