### PR TITLE
Add support to blacklist a single claim

### DIFF
--- a/ADSOrcid/models.py
+++ b/ADSOrcid/models.py
@@ -64,13 +64,15 @@ class Records(Base):
     created = Column(UTCDateTime, default=get_date)
     updated = Column(UTCDateTime, default=get_date)
     processed = Column(UTCDateTime)
+    status = Column(String(255))
     
     def toJSON(self):
         return {'id': self.id, 'bibcode': self.bibcode,
                 'authors': self.authors and json.loads(self.authors) or [],
                 'claims': self.claims and json.loads(self.claims) or {},
                 'created': self.created and get_date(self.created).isoformat() or None, 'updated': self.updated and get_date(self.updated).isoformat() or None, 
-                'processed': self.processed and get_date(self.processed).isoformat() or None
+                'processed': self.processed and get_date(self.processed).isoformat() or None,
+                'status': self.status and json.loads(self.status) or {}
                 }
 
 

--- a/ADSOrcid/tests/test_models.py
+++ b/ADSOrcid/tests/test_models.py
@@ -45,7 +45,7 @@ class Test(unittest.TestCase):
         rec = Records(bibcode='foo', created='2009-09-03T20:56:35.450686Z')
 
         self.assertDictEqual(rec.toJSON(),
-             {'bibcode': 'foo', 'created': '2009-09-03T20:56:35.450686+00:00', 'updated': None, 'processed': None, 'claims': {}, 'id': None, 'authors': []})
+             {'bibcode': 'foo', 'created': '2009-09-03T20:56:35.450686+00:00', 'updated': None, 'processed': None, 'claims': {}, 'id': None, 'authors': [], 'status': {}})
         
         with self.assertRaisesRegexp(Exception, 'IntegrityError'):
             with app.session_scope() as session:

--- a/ADSOrcid/tests/test_updater.py
+++ b/ADSOrcid/tests/test_updater.py
@@ -192,6 +192,35 @@ class Test(unittest.TestCase):
         self.assertEqual(doc_blank['claims']['verified'],
                          ['-','-','-','-','-','0000-0009-8765-4321'])
 
+        # reject blacklisted claim
+        doc_blacklisted = {
+            'bibcode': '2022Test.........2B',
+            'authors': [
+                "Evans, D. F.",
+                "Southworth, J.",
+                "Smalley, B.",
+                "Jorgensen, U. G.",
+                "Dominik, M.",
+                "Tronsgaard, R."
+            ],
+            'claims': {'verified': ['0000-0009-8765-4321', '-', '-', '-', '-', '-']},
+            'status': {'blacklisted': ['0000-0001-2345-6789']}
+        }
+        r_blacklisted = updater.update_record(
+            doc_blacklisted,
+            {
+                'bibcode': '2022Test.........2B',
+                'orcidid': '0000-0001-2345-6789',
+                'account_id': '3',
+                'orcid_name': ['Southworth, X.'],
+                'author': [''],
+                'name': ''
+            },
+            0.75
+        )
+        self.assertIsNone(r_blacklisted)
+        self.assertEqual(doc_blacklisted['claims']['verified'], ['0000-0009-8765-4321', '-', '-', '-', '-', '-'])
+
     def test_exact_match(self):
         """
         Given an author with an exact name match, the Levenshtein matching function should not be called.

--- a/ADSOrcid/updater.py
+++ b/ADSOrcid/updater.py
@@ -59,6 +59,14 @@ def update_record(rec, claim, min_levenshtein):
     rec['claims'] = claims
     authors = rec.get('authors', [])
 
+    # check to see if claim (ORCID ID + bibcode) is blacklisted
+    if rec.get('status') \
+            and rec.get('status').get('blacklisted') \
+            and claim['orcidid'] in rec.get('status').get('blacklisted'):
+        logger.info('ORCID ID {0} is blacklisted from bibcode {1}. Claim will be rejected.'.
+                    format(claim['orcidid'], claim['bibcode']))
+        return None
+
     # make sure the claims have the necessary structure
     fld_name = u'unverified'
     if 'account_id' in claim and claim['account_id']: # the claim was made by ADS verified user


### PR DESCRIPTION
Resolves #101.

Note: while there is a change to the model, alembic is not required because the column already exists in the database (the column was originally present in the model and in the prod database. It was removed from the model but never removed via alembic migration, so this change is just adding the column back again to the model, and making use of it).